### PR TITLE
fix: Specify source maps in Vite plugins

### DIFF
--- a/packages/near-operation-file/index.ts
+++ b/packages/near-operation-file/index.ts
@@ -10,7 +10,11 @@ export default function graphQLCodegen(): Plugin {
         return;
       }
 
-      return `export * from '${id}.ts'`;
+      return {
+        code: `export * from '${id}.ts'`,
+        // Empty sourcemap to avoid warnings
+        map: { mappings: '' },
+      };
     },
   };
 }

--- a/packages/near-operation-file/index.ts
+++ b/packages/near-operation-file/index.ts
@@ -2,7 +2,7 @@ import { type Plugin } from 'vite';
 
 export default function graphQLCodegen(): Plugin {
   return {
-    name: 'graphql-codegen',
+    name: 'graphql-codegen-near-operation-file',
 
     // TODO: Invoke GraphQL Codegen on the fly
     load(id) {

--- a/packages/vue-query-block/vite-plugin.ts
+++ b/packages/vue-query-block/vite-plugin.ts
@@ -13,7 +13,11 @@ export default function vueQueryBlock(): Plugin {
       // To avoid parsing errors, we must transform the custom <query> block.
       // The actual GraphQL stuff gets done by graphql-codegen.
       // So, just returning an empty function is enough.
-      return `export default () => {}`;
+      return {
+        code: 'export default () => {}',
+        // Empty sourcemap to avoid warnings
+        map: { mappings: '' },
+      };
     },
   };
 }

--- a/packages/vue-query-block/vite-plugin.ts
+++ b/packages/vue-query-block/vite-plugin.ts
@@ -2,7 +2,7 @@ import { type Plugin } from 'vite';
 
 export default function vueQueryBlock(): Plugin {
   return {
-    name: 'graphql-codegen',
+    name: 'graphql-codegen-vue-query-block',
 
     // TODO: Invoke GraphQL Codegen on the fly
     transform(_code, id) {


### PR DESCRIPTION
To avoid the following warning:
> Sourcemap is likely to be incorrect: a plugin (graphql-codegen) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
